### PR TITLE
[18.0][FIX] edi_oca: test should only be executed after all modules have been installed

### DIFF
--- a/edi_oca/tests/common.py
+++ b/edi_oca/tests/common.py
@@ -13,6 +13,7 @@ from odoo.addons.component.tests.common import (
 )
 
 
+@tagged("-at_install", "post_install")
 class EDIBackendTestMixin:
     @classmethod
     def _setup_context(cls, **kw):


### PR DESCRIPTION
to resolve red CI of modules that depend on `edi_oca`

```
2025-08-11 11:05:51,967 555 ERROR odoo odoo.tests.suite: ERROR: setUpClass (odoo.addons.edi_oca.tests.test_security.TestEDIExchangeRecordSecurity)
Traceback (most recent call last):
  File "/opt/odoo-venv/lib/python3.10/site-packages/odoo/addons/edi_oca/tests/common.py", line 94, in setUpClass
    cls._setup_records()
  File "/opt/odoo-venv/lib/python3.10/site-packages/odoo/addons/edi_oca/tests/test_security.py", line 53, in _setup_records
```
```
errors that caused failure (10):
2025-08-11 11:05:51,963 555 ERROR odoo odoo.sql_db: bad query: b'INSERT INTO "res_partner" ("active", "color", "create_date", "create_uid", "email", "is_company", "lang", "message_bounce", "name", "type", "tz", "user_id", "write_date", "write_uid") VALUES (true, 0, \'2025-08-11 11:05:51.620290\', 1, \'poor.partner@ododo.com\', false, \'en_US\', 0, \'Poor Partner (not integrating one)\', \'contact\', NULL, NULL, \'2025-08-11 11:05:51.620290\', 1) RETURNING "id"'
ERROR: null value in column "autopost_bills" violates not-null constraint
```