### PR TITLE
[FIX] edi_core_oca: test should only be executed after all modules have been installed

### DIFF
--- a/edi_core_oca/tests/common.py
+++ b/edi_core_oca/tests/common.py
@@ -5,9 +5,10 @@
 
 import os
 
-from odoo.tests.common import TransactionCase
+from odoo.tests.common import TransactionCase, tagged
 
 
+@tagged("-at_install", "post_install")
 class EDIBackendTestMixin:
     @classmethod
     def _setup_context(cls, **kw):


### PR DESCRIPTION
To resolve red CI of modules that depend on `edi_core_oca`.

```
2025-08-11 11:05:51,967 555 ERROR odoo odoo.tests.suite: ERROR: setUpClass (odoo.addons.edi_oca.tests.test_security.TestEDIExchangeRecordSecurity)
Traceback (most recent call last):
  File "/opt/odoo-venv/lib/python3.10/site-packages/odoo/addons/edi_oca/tests/common.py", line 94, in setUpClass
    cls._setup_records()
  File "/opt/odoo-venv/lib/python3.10/site-packages/odoo/addons/edi_oca/tests/test_security.py", line 53, in _setup_records
```

- The error occurs because some dependent modules indirectly rely on account, which adds the required field autopost_bills to res.partner.

- When creating a new user in TestEDIExchangeRecordSecurity, a related partner record is also created. However, the default value for autopost_bills is not yet initialized at that point, leading to a null value and causing the failure.

**FIX**
- Add the @tagged("-at_install") decorator to the base mixin. This avoids a race condition where the parent class’s setUp method may execute before all module models are fully loaded. With this change, the test environment is initialized only after the Odoo environment is fully ready, ensuring stability.